### PR TITLE
test(cmake/valgrind): add valgrind. It is disabled by default because…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,4 +21,5 @@ RUN sudo apt update && \
     cppcheck \
     ccache \
     doxygen \
-    graphviz
+    graphviz \
+    valgrind

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -12,9 +12,10 @@ option(INSTALL_GTEST "Install GTest" OFF)
 FetchContent_MakeAvailable(googletest)
 
 include(GoogleTest)
+include(Valgrind)
 
 macro(AddTests target)
-    #message("Adding tests to ${target}")
     target_link_libraries("${target}" PRIVATE gtest_main gmock)
     gtest_discover_tests("${target}")
+    AddValgrindInstrumentation("${target}")
 endmacro()

--- a/cmake/Valgrind.cmake
+++ b/cmake/Valgrind.cmake
@@ -1,0 +1,27 @@
+set(ENABLE_VALGRIND FALSE)
+
+if(ENABLE_VALGRIND)
+    message(STATUS "Valgrind is enabled")
+    find_program(VALGRIND_PATH valgrind)
+    if(NOT VALGRIND_PATH)
+        message(WARNING "valgrind not found")
+        set(ENABLE_VALGRIND FALSE)
+    endif()
+else()
+    message(STATUS "Valgrind is disabled")
+endif()
+
+function(AddValgrindInstrumentation target)
+    if(ENABLE_VALGRIND)
+        add_test(
+            NAME "memcheck_${target}"
+            COMMAND "${VALGRIND_PATH}" 
+                    --leak-check=full 
+                    --show-leak-kinds=all 
+                    --track-origins=yes 
+                    --error-exitcode=1 
+                    "$<TARGET_FILE:${target}>"
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        )
+    endif()
+endfunction()


### PR DESCRIPTION
… it is very slow